### PR TITLE
performance tweak 2: mergeTopicNames 16s -> 0.03s total benchmark

### DIFF
--- a/src/producer/groupMessagesPerPartition.js
+++ b/src/producer/groupMessagesPerPartition.js
@@ -3,9 +3,14 @@ module.exports = ({ topic, partitionMetadata, messages, partitioner }) => {
     return {}
   }
 
-  return messages.reduce((result, message) => {
+  const grouping = {}
+  for (const message of messages) {
     const partition = partitioner({ topic, partitionMetadata, message })
-    const current = result[partition] || []
-    return Object.assign(result, { [partition]: [...current, message] })
-  }, {})
+    if (grouping[partition] === undefined) {
+      grouping[partition] = []
+    }
+    grouping[partition].push(message)
+  }
+
+  return grouping
 }

--- a/src/producer/mergeTopicMessages.spec.js
+++ b/src/producer/mergeTopicMessages.spec.js
@@ -1,0 +1,25 @@
+const old = require('./mergeTopicMessages_old')
+const perf = require('./mergeTopicMessages_performant')
+
+describe('Producer > performantMergeTopicMessages', () => {
+  test('group messages per partition', () => {
+    const tm = Array(10)
+      .fill(0)
+      .map((_, i) => ({
+        topic: `topic_${i}`,
+        messages: new Array(10).fill(0).map((_, i) => ({
+          key: `key-${i}`,
+          value: `value-${i}`,
+          headers: {
+            [`header-a${i}`]: `header-value-a${i}`,
+            [`header-b${i}`]: `header-value-b${i}`,
+            [`header-c${i}`]: `header-value-c${i}`,
+          },
+        })),
+      }))
+
+    const resultOld = old.getMergedTopicMessages(tm)
+    const resultPerf = perf.getMergedTopicMessages(tm)
+    expect(resultOld).toEqual(resultPerf)
+  })
+})

--- a/src/producer/mergeTopicMessages_benchmark.spec.js
+++ b/src/producer/mergeTopicMessages_benchmark.spec.js
@@ -1,0 +1,94 @@
+const old = require('./mergeTopicMessages_old')
+const perf = require('./mergeTopicMessages_performant')
+
+const getPartition = message => `partition_${Math.floor(Math.random() * 1)}`
+
+// ffs jest, go away.
+console.log = (...arg) => {
+  arg.forEach(a => process.stdout.write(a))
+  process.stdout.write('\n')
+}
+
+const genMessages = n =>
+  Array(n)
+    .fill(0)
+    .map(x => ({ value: { val: Math.random() } }))
+
+const sizes = [10, 50, 100, 500, 1000, 10000, 20000, 50000]
+
+const ms = bi => {
+  return (Number(bi) / 1000000).toFixed(2)
+}
+
+const time = async (name, values, fn) => {
+  const start = process.hrtime.bigint()
+  const result = await fn(values)
+  const end = process.hrtime.bigint()
+  return { result, time: end - start }
+}
+
+let totalPerf = 0n
+let totalKafakjs = 0n
+
+const runPerfloop = async args => {
+  const { getMessages, one, two, name } = args
+  console.log('\n-----------------------------')
+  console.log(`Running perftest for ${name}`)
+  for (const size of sizes) {
+    const messages = getMessages(size)
+    const kresult = await time('kafkajs', messages, one)
+    const nresult = await time('new', messages, two)
+    const k = kresult.time
+    const n = nresult.time
+    const perfImprovement = (Number(k) / Number(n)).toFixed(1)
+    totalKafakjs += kresult.time
+    totalPerf += nresult.time
+    console.log(
+      `Run for ${(size + '     ').slice(0, 5)} messages: (${ms(k)}ms) -> (${ms(
+        n
+      )}}ms) = ${perfImprovement}x`
+    )
+    // check we've actually got correct values...
+    expect(kresult.result).toEqual(nresult.result)
+  }
+  console.log('-----------------------------')
+}
+
+async function go(fn) {
+  await fn()
+
+  const secs = bi => (Number(bi / 1000000n) / 1000).toFixed(2)
+
+  console.log('---------------------')
+  console.log('#####################')
+  console.log('Final results:')
+  console.log(`Total benchmark time kafkajs: ${secs(totalKafakjs)}s`)
+  console.log(`Total benchmark time perf   : ${secs(totalPerf)}s`)
+  const improvement = Number(totalKafakjs / totalPerf)
+  console.log(`Average improvement: ${improvement.toFixed(2)}x`)
+}
+
+describe('mergeTopicMessages', () => {
+  test('benchmark', async () => {
+    await go(async () => {
+      const randomTopic = max => `t_${Math.floor(Math.random() * max)}`
+      const messages = genMessages(50000)
+      const messageMax = 50000
+      const messagesBlockSize = 100
+
+      const topicBatches = [100, 200, 500, 1000, 2000]
+      for (const b of topicBatches) {
+        const topicMessages = Array(messageMax)
+          .fill(0)
+          .map(x => ({ topic: randomTopic(b), messages: messages.slice(0, messagesBlockSize) }))
+
+        await runPerfloop({
+          name: `hot-loop-2a: many topic-message pairs, t=${b}`,
+          one: old.getMergedTopicMessages,
+          two: perf.getMergedTopicMessages,
+          getMessages: size => topicMessages.slice(0, size),
+        })
+      }
+    })
+  })
+})

--- a/src/producer/mergeTopicMessages_old.js
+++ b/src/producer/mergeTopicMessages_old.js
@@ -1,0 +1,39 @@
+const { KafkaJSNonRetriableError } = require('../errors')
+
+module.exports = {
+  getMergedTopicMessages(topicMessages) {
+    if (topicMessages.some(({ topic }) => !topic)) {
+      throw new KafkaJSNonRetriableError(`Invalid topic`)
+    }
+
+    for (const { topic, messages } of topicMessages) {
+      if (!messages) {
+        throw new KafkaJSNonRetriableError(
+          `Invalid messages array [${messages}] for topic "${topic}"`
+        )
+      }
+
+      const messageWithoutValue = messages.find(message => message.value === undefined)
+      if (messageWithoutValue) {
+        throw new KafkaJSNonRetriableError(
+          `Invalid message without value for topic "${topic}": ${JSON.stringify(
+            messageWithoutValue
+          )}`
+        )
+      }
+    }
+
+    const mergedTopicMessages = topicMessages.reduce((merged, { topic, messages }) => {
+      const index = merged.findIndex(({ topic: mergedTopic }) => topic === mergedTopic)
+
+      if (index === -1) {
+        merged.push({ topic, messages })
+      } else {
+        merged[index].messages = [...merged[index].messages, ...messages]
+      }
+
+      return merged
+    }, [])
+    return mergedTopicMessages
+  },
+}

--- a/src/producer/mergeTopicMessages_performant.js
+++ b/src/producer/mergeTopicMessages_performant.js
@@ -14,15 +14,13 @@ module.exports = {
 
     for (let i = 0; i < topicMessages.length; i++) {
       const tm = topicMessages[i]
-      if (!tm.messages) {
+      if (!tm.topic) {
+        throw new KafkaJSNonRetriableError(`Invalid topic`)
+      } else if (!tm.messages) {
         throw new KafkaJSNonRetriableError(
           `Invalid messages array [${tm.messages}] for topic "${tm.topic}"`
         )
-      }
-      if (groups[tm.topic] === undefined) {
-        if (!tm.topic) {
-          throw new KafkaJSNonRetriableError(`Invalid topic`)
-        }
+      } else if (groups[tm.topic] === undefined) {
         groups[tm.topic] = [tm.messages]
         topicNames.push(tm.topic)
       } else {
@@ -46,7 +44,7 @@ module.exports = {
       for (let j = 0; j < groupLen; j++) {
         for (let k = 0; k < group[j].length; k++) {
           const msg = group[j][k]
-          if (!msg.value) {
+          if (msg.value === undefined) {
             throw new KafkaJSNonRetriableError(
               `Invalid message without value for topic "${topic}": ${JSON.stringify(msg.value)}`
             )

--- a/src/producer/mergeTopicMessages_performant.js
+++ b/src/producer/mergeTopicMessages_performant.js
@@ -1,0 +1,62 @@
+const { KafkaJSNonRetriableError } = require('../errors')
+
+module.exports = {
+  getMergedTopicMessages(topicMessages) {
+    // inspiration for faster array ops: https://dev.to/uilicious/javascript-array-push-is-945x-faster-than-array-concat-1oki
+    const groups = {
+      // [topicname]: [[]]
+    }
+    const topicNames = []
+
+    // store each array(array)
+    // loop over each, pre-allocate a results array
+    // naive fill array
+
+    for (let i = 0; i < topicMessages.length; i++) {
+      const tm = topicMessages[i]
+      if (!tm.messages) {
+        throw new KafkaJSNonRetriableError(
+          `Invalid messages array [${tm.messages}] for topic "${tm.topic}"`
+        )
+      }
+      if (groups[tm.topic] === undefined) {
+        if (!tm.topic) {
+          throw new KafkaJSNonRetriableError(`Invalid topic`)
+        }
+        groups[tm.topic] = [tm.messages]
+        topicNames.push(tm.topic)
+      } else {
+        groups[tm.topic].push(tm.messages)
+      }
+    }
+    const topicNameLen = topicNames.length
+
+    // now we produce one result array
+    const result = Array(topicNameLen)
+    for (let i = 0; i < topicNameLen; i++) {
+      const topic = topicNames[i]
+
+      const group = groups[topic]
+      const totalLength = group.map(g => g.length).reduce((acc, cur) => acc + cur, 0)
+      const resultsArray = Array(totalLength)
+
+      // add each array. nested loop
+      let offset = 0
+      const groupLen = group.length
+      for (let j = 0; j < groupLen; j++) {
+        for (let k = 0; k < group[j].length; k++) {
+          const msg = group[j][k]
+          if (!msg.value) {
+            throw new KafkaJSNonRetriableError(
+              `Invalid message without value for topic "${topic}": ${JSON.stringify(msg.value)}`
+            )
+          }
+          resultsArray[offset + k] = msg
+        }
+        offset += group[j].length
+      }
+      result[i] = { topic, messages: resultsArray }
+    }
+    return result
+  },
+}

--- a/src/producer/messageProducer.js
+++ b/src/producer/messageProducer.js
@@ -1,6 +1,7 @@
 const createSendMessages = require('./sendMessages')
 const { KafkaJSError, KafkaJSNonRetriableError } = require('../errors')
 const { CONNECTION_STATUS } = require('../network/connectionStatus')
+const { getMergedTopicMessages } = require('./mergeTopicMessages_performant')
 
 module.exports = ({
   logger,
@@ -52,45 +53,13 @@ module.exports = ({
    * @returns {Promise}
    */
   const sendBatch = async ({ acks = -1, timeout, compression, topicMessages = [] }) => {
-    if (topicMessages.some(({ topic }) => !topic)) {
-      throw new KafkaJSNonRetriableError(`Invalid topic`)
-    }
-
     if (idempotent && acks !== -1) {
       throw new KafkaJSNonRetriableError(
         `Not requiring ack for all messages invalidates the idempotent producer's EoS guarantees`
       )
     }
-
-    for (const { topic, messages } of topicMessages) {
-      if (!messages) {
-        throw new KafkaJSNonRetriableError(
-          `Invalid messages array [${messages}] for topic "${topic}"`
-        )
-      }
-
-      const messageWithoutValue = messages.find(message => message.value === undefined)
-      if (messageWithoutValue) {
-        throw new KafkaJSNonRetriableError(
-          `Invalid message without value for topic "${topic}": ${JSON.stringify(
-            messageWithoutValue
-          )}`
-        )
-      }
-    }
-
     validateConnectionStatus()
-    const mergedTopicMessages = topicMessages.reduce((merged, { topic, messages }) => {
-      const index = merged.findIndex(({ topic: mergedTopic }) => topic === mergedTopic)
-
-      if (index === -1) {
-        merged.push({ topic, messages })
-      } else {
-        merged[index].messages = [...merged[index].messages, ...messages]
-      }
-
-      return merged
-    }, [])
+    const mergedTopicMessages = getMergedTopicMessages(topicMessages)
 
     return await sendMessages({
       acks,

--- a/src/producer/messageProducer.js
+++ b/src/producer/messageProducer.js
@@ -58,8 +58,8 @@ module.exports = ({
         `Not requiring ack for all messages invalidates the idempotent producer's EoS guarantees`
       )
     }
-    validateConnectionStatus()
     const mergedTopicMessages = getMergedTopicMessages(topicMessages)
+    validateConnectionStatus()
 
     return await sendMessages({
       acks,


### PR DESCRIPTION
This is a funny one. It addresses the manipulation of this structure:
```
// (pseudotyping, just here for clarity)
type TopicMessageBlock = { topic: string, messages: msg[] }
type BlockCollection = TopicMessageBlock[]
```

Kafkajs tries to merge these into a smaller BlockCollection by combining messages from similar Blocks

NOTE: These benchmarks were run on my local machine, not ECS. We'll see much slower results on ECS.

## Benchmark 1:
The benchmarks below generate `n` Blocks with `t` topics randomly assigned. Each Block.messages is of length 3.

Note: If i reduce `t` to 1, my machine hangs at n=20,000. That is - if all blocks need to be merged, it's game over.

```
-----------------------------
Running perftest for hot-loop-2a: many topic-message pairs, t=100
Run for 10    messages: (0.36ms) -> (0.89}ms) = 0.4x
Run for 50    messages: (0.61ms) -> (1.03}ms) = 0.6x
Run for 100   messages: (1.05ms) -> (2.06}ms) = 0.5x
Run for 500   messages: (9.09ms) -> (10.21}ms) = 0.9x
Run for 1000  messages: (14.27ms) -> (8.08}ms) = 1.8x
Run for 10000 messages: (533.80ms) -> (23.90}ms) = 22.3x
Run for 20000 messages: (3175.00ms) -> (35.34}ms) = 89.8x
Run for 50000 messages: (24423.75ms) -> (90.52}ms) = 269.8x
-----------------------------

-----------------------------
Running perftest for hot-loop-2a: many topic-message pairs, t=200
Run for 10    messages: (0.03ms) -> (0.05}ms) = 0.6x
Run for 50    messages: (0.05ms) -> (0.11}ms) = 0.5x
Run for 100   messages: (0.08ms) -> (0.13}ms) = 0.6x
Run for 500   messages: (0.99ms) -> (0.65}ms) = 1.5x
Run for 1000  messages: (22.00ms) -> (1.12}ms) = 19.7x
Run for 10000 messages: (249.87ms) -> (17.03}ms) = 14.7x
Run for 20000 messages: (1456.62ms) -> (46.03}ms) = 31.6x
Run for 50000 messages: (11858.67ms) -> (179.08}ms) = 66.2x
-----------------------------

-----------------------------
Running perftest for hot-loop-2a: many topic-message pairs, t=500
Run for 10    messages: (0.02ms) -> (0.07}ms) = 0.3x
Run for 50    messages: (0.09ms) -> (0.09}ms) = 1.0x
Run for 100   messages: (0.31ms) -> (0.13}ms) = 2.3x
Run for 500   messages: (6.17ms) -> (1.20}ms) = 5.1x
Run for 1000  messages: (11.06ms) -> (12.41}ms) = 0.9x
Run for 10000 messages: (133.89ms) -> (18.64}ms) = 7.2x
Run for 20000 messages: (606.79ms) -> (32.54}ms) = 18.6x
Run for 50000 messages: (4611.14ms) -> (95.94}ms) = 48.1x
-----------------------------

-----------------------------
Running perftest for hot-loop-2a: many topic-message pairs, t=1000
Run for 10    messages: (0.01ms) -> (0.04}ms) = 0.2x
Run for 50    messages: (0.03ms) -> (0.10}ms) = 0.3x
Run for 100   messages: (0.09ms) -> (0.14}ms) = 0.6x
Run for 500   messages: (1.54ms) -> (0.68}ms) = 2.2x
Run for 1000  messages: (5.28ms) -> (1.30}ms) = 4.1x
Run for 10000 messages: (148.74ms) -> (16.71}ms) = 8.9x
Run for 20000 messages: (396.06ms) -> (42.88}ms) = 9.2x
Run for 50000 messages: (2430.55ms) -> (108.66}ms) = 22.4x
-----------------------------

-----------------------------
Running perftest for hot-loop-2a: many topic-message pairs, t=2000
Run for 10    messages: (0.01ms) -> (0.04}ms) = 0.3x
Run for 50    messages: (0.03ms) -> (0.10}ms) = 0.3x
Run for 100   messages: (0.07ms) -> (0.14}ms) = 0.5x
Run for 500   messages: (1.51ms) -> (0.76}ms) = 2.0x
Run for 1000  messages: (5.26ms) -> (1.25}ms) = 4.2x
Run for 10000 messages: (182.07ms) -> (13.22}ms) = 13.8x
Run for 20000 messages: (452.21ms) -> (37.64}ms) = 12.0x
Run for 50000 messages: (1650.25ms) -> (97.65}ms) = 16.9x
-----------------------------

-----------------------------
Running perftest for hot-loop-2b: few (5) large/5 topic-message pairs
Run for 10    messages: (0.01ms) -> (0.01}ms) = 0.5x
Run for 50    messages: (0.00ms) -> (0.00}ms) = 0.9x
Run for 100   messages: (0.00ms) -> (0.00}ms) = 0.9x
Run for 500   messages: (0.01ms) -> (0.01}ms) = 1.5x
Run for 1000  messages: (0.02ms) -> (0.01}ms) = 1.1x
Run for 10000 messages: (0.16ms) -> (0.09}ms) = 1.7x
Run for 20000 messages: (0.45ms) -> (0.29}ms) = 1.5x
Run for 50000 messages: (1.68ms) -> (0.71}ms) = 2.4x
-----------------------------

-----------------------------
Running perftest for hot-loop-2b: one large topic-message pair
Run for 10    messages: (0.00ms) -> (0.00}ms) = 0.8x
Run for 50    messages: (0.00ms) -> (0.00}ms) = 0.7x
Run for 100   messages: (0.00ms) -> (0.00}ms) = 0.8x
Run for 500   messages: (0.00ms) -> (0.01}ms) = 0.5x
Run for 1000  messages: (0.00ms) -> (0.01}ms) = 0.3x
Run for 10000 messages: (0.02ms) -> (0.10}ms) = 0.2x
Run for 20000 messages: (0.05ms) -> (0.33}ms) = 0.2x
Run for 50000 messages: (0.14ms) -> (0.74}ms) = 0.2x
-----------------------------
---------------------
#####################
Final results:
Total benchmark time kafkajs: 52.39s
Total benchmark time perf   : 0.90s
Average improvement: 58.00x
```